### PR TITLE
Add cursors, coerce namespace and keys to property paths

### DIFF
--- a/src/next/create.js
+++ b/src/next/create.js
@@ -91,6 +91,9 @@ export function create(namespace, store) {
     },
     resets(key) {
       return ns.reset.bind(ns, key);
+    },
+    version() {
+      return selector('@@version', 0)
     }
   }
 

--- a/src/next/create.js
+++ b/src/next/create.js
@@ -1,9 +1,15 @@
-import isFunction from 'lodash/isFunction';
-import isString from 'lodash/isString';
-import result from 'lodash/result';
 import flow from 'lodash/flow';
-import property from 'lodash/property';
+import get from 'lodash/get';
+import isFunction from 'lodash/isFunction';
+import isNil from 'lodash/isNil';
+import isObject from 'lodash/isObject';
+import isString from 'lodash/isString';
 import mapValues from 'lodash/mapValues';
+import property from 'lodash/property';
+import result from 'lodash/result';
+import toPath from 'lodash/toPath';
+
+import invariant from 'invariant';
 
 import { BIND } from './reducer';
 
@@ -23,8 +29,12 @@ export function assign(namespace, key, value) {
 
 export function create(namespace, store) {
   const { dispatch, getState } = store;
+
+  const selectNamespace =
+    property(['namespace', ...toPath(namespace)])
+
   const getNamespace =
-    flow(getState, property(['namespace', namespace]));
+    flow(getState, selectNamespace);
 
   function selector(key, __) {
     return arguments.length > 0 ?
@@ -38,6 +48,7 @@ export function create(namespace, store) {
       // curry assign with target
         isString(target) ?
           dispatcher.bind(this, target)
+      // TODO interpret array as property.path
       // map target ({key: value}) => assign
       : mapValues(target, (value, key) => dispatcher(key, value))
     // deferred selector
@@ -51,7 +62,7 @@ export function create(namespace, store) {
     )
   }
 
-  return {
+  const ns = {
     assign: dispatcher,
     assigns(key, selector) {
       return dispatcher(key, (value, ...args) =>
@@ -60,13 +71,28 @@ export function create(namespace, store) {
         : value
       )
     },
+    cursor(path, defaultValue={}) {
+      let nspath = toPath([toPath(namespace), toPath(path)])
+      let cursor = create(nspath, store);
+
+      return cursor;
+    },
     dispatch,
     select: selector,
     selects() {
       return selector.bind(null, ...arguments);
     },
     touched(key) {
-      return selector(['@@touched'].concat(key), false);
+      return selector(['@@touched', ...toPath(key)], false);
+    },
+    reset(key) {
+      dispatcher(key, null);
+      dispatcher(['@@touched', ...toPath(key)], null);
+    },
+    resets(key) {
+      return ns.reset.bind(ns, key);
     }
   }
+
+  return ns;
 }

--- a/src/next/reducer.js
+++ b/src/next/reducer.js
@@ -3,9 +3,11 @@ import get from 'lodash/get';
 import merge from 'lodash/merge';
 import set from 'lodash/set';
 import toPath from 'lodash/toPath';
+import clone from 'lodash/clone';
 
 
 export const BIND = 'BIND_NAMESPACE_NEXT';
+
 
 export function namespaceReducer (state={}, action={}) {
 
@@ -15,19 +17,35 @@ export function namespaceReducer (state={}, action={}) {
     namespace = toPath(namespace);
     key = toPath(key);
 
-    let valuePath = concat(namespace, key);
-    let touchPath = concat(namespace, '@@touched', key);
+    let changedPath = concat(namespace, key);
+    let touchedPath = concat(namespace, '@@touched', key);
+    let versionPath = concat(namespace, '@@version');
 
-    if (value !== get(state, valuePath)) {
-      state =
-        merge(
-          set({}, namespace, {}),
-          state,
-          set({}, valuePath, value),
-          set({}, touchPath, true))
+    if (value !== get(state, changedPath)) {
+      let version = get(state, versionPath, 0) + 1;
+      let fragment = set({}, namespace, get(state, namespace));
+
+      clonePath(fragment, changedPath);
+      clonePath(fragment, touchedPath);
+
+      set(fragment, versionPath, version);
+      set(fragment, changedPath, value);
+      set(fragment, touchedPath, true);
+
+      state = merge(clone(state), fragment)
     }
   }
 
 
   return state;
+}
+
+
+function clonePath (target, path) {
+  path.forEach((key, idx, col) => {
+    key = col.slice(0, idx);
+    set(target, key, clone(get(target, key)))
+  })
+
+  return target;
 }

--- a/src/next/reducer.js
+++ b/src/next/reducer.js
@@ -1,19 +1,33 @@
-import result from 'lodash/result';
+import concat from 'lodash/concat';
+import get from 'lodash/get';
+import merge from 'lodash/merge';
+import set from 'lodash/set';
+import toPath from 'lodash/toPath';
 
 
 export const BIND = 'BIND_NAMESPACE_NEXT';
 
 export function namespaceReducer (state={}, action={}) {
+
   if (action.type === BIND) {
     let { payload: { namespace, key, value } } = action
 
-    let prev = result(state, namespace, {});
-    let touched = result(prev, '@@touched', {});
-    let next = {
-      ...prev, [key]: value, ['@@touched']: { ...touched, [key]: true } };
+    namespace = toPath(namespace);
+    key = toPath(key);
 
-    state = { ...state, [namespace]: next };
+    let valuePath = concat(namespace, key);
+    let touchPath = concat(namespace, '@@touched', key);
+
+    if (value !== get(state, valuePath)) {
+      state =
+        merge(
+          set({}, namespace, {}),
+          state,
+          set({}, valuePath, value),
+          set({}, touchPath, true))
+    }
   }
+
 
   return state;
 }


### PR DESCRIPTION
Coerce namespace and key to property paths
Supports assignment to deeply nested keys

``` es6
assign('some.key.value', 'meow')
// before
// { 'some.key.value': 'meow' }

// after
// { some: { key: { value: 'meow' } } }
```
- correct use of property paths
- add methods to reset namespace
- track updates by version
- add version method
- `Connect` tracks changes by version
- Add cursor method

``` es6
let space = ns.create('space');
let child = space.cursor('child');
let grandchild = child.cursor('grandchild');

grandchild.assign('fruit', 'tomato');
grandchild.select()
// { fruit: 'tomato' }

space.select('child.grandchild.fruit')
// tomato
```
